### PR TITLE
Add `AmbientCapabilities=CAP_NET_BIND_SERVICE` to the systemd service.

### DIFF
--- a/templates/node_exporter.service.j2
+++ b/templates/node_exporter.service.j2
@@ -6,6 +6,7 @@ After=network-online.target
 StartLimitInterval=0
 
 [Service]
+AmbientCapabilities=CAP_NET_BIND_SERVICE
 User={{ node_exporter_system_user }}
 ExecStart={{ node_exporter_binary_install_dir }}/node_exporter \
 {% for collector in node_exporter_enabled_collectors -%}


### PR DESCRIPTION
Newer versions of systemd change the way they handle Linux capabilities, so even though we're setting this capability on the file itself, it gets ignored when the file is run.

The more modern way of doing this in systemd is using `AmbientCapabilities`